### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@ A game where you train and proliferate fighting creatures.
 
 **Roadmap:**
 
-	0.01 Develop a platform agnostic avant garde engine for projecting 2d sprites with transparency into sudo 3d space with forced perspective/practical effect trickery
-	0.02 Work out a control system that moves a 2d world around you to create the illusion of a 3d world rather than moving you through a 3d world {QWEASD}
-	0.03 Develop point and click interactions so sprites can be clicked to trigger scripts
-	0.04 testing
-	0.05 Develop the combat system
-	0.06 add conversion/conversation to combat
-	0.07 Develop the reproductive system
-	0.08 start on the beastiary and inventory
-	0.09 start building the world and main story
-	0.10 playable demo
-	0.11 expand on what people like
+        0.01 Develop a platform agnostic avant-garde engine for projecting 2D sprites with transparency into pseudo 3D space with forced perspective/practical effect trickery
+        0.02 Work out a control system that moves a 2D world around you to create the illusion of a 3D world rather than moving you through a 3D world {QWEASD}
+        0.03 Develop point and click interactions so sprites can be clicked to trigger scripts
+        0.04 Testing
+        0.05 Develop the combat system
+        0.06 Add conversation to combat
+        0.07 Develop the reproductive system
+        0.08 Start on the bestiary and inventory
+        0.09 Start building the world and main story
+        0.10 Playable demo
+        0.11 Expand on what people like
 
 ## License
 This project is released under the **Arc-9 : Read Only License**.


### PR DESCRIPTION
## Summary
- fix spelling and capitalization mistakes in the roadmap section of the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68560320ee108328bc35df0a98c4b1a4